### PR TITLE
Update login_server.R

### DIFF
--- a/R/login_server.R
+++ b/R/login_server.R
@@ -154,7 +154,8 @@ login_server <- function(id = "login_system",
                          emayili_user,
                          emayili_password,
                          emayili_host,
-                         emayili_port
+                         emayili_port,
+                         useLoginModal = TRUE
 ){
   
   moduleServer(
@@ -265,13 +266,13 @@ login_server <- function(id = "login_system",
           )
         } else {
           
-          showModal(
+          if (useLoginModal) { showModal(
             
             modalDialog(title = txt$get("login_succ_t"),
                         p(txt$get("login_succ_b")),
                         footer = modalButton("OK")
             )
-          )
+          ) }
           
           
           active_user$is_logged <- TRUE


### PR DESCRIPTION
May I suggest an extra parameter for the server -- "useLoginModal" (logical, default True) -- which controls whether modal dialogs are shown?
I'm interested in this for logging in, in particular (possibly might want to use it for the other functions, so could have a more general "useAllModals" parameter instead), because I observe the change to auth$is_logged and react accordingly (so it's unnecessary to make the user click on a dialog button as well).
thanks, Andrew