### PR TITLE
Update for gmailr 3.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,4 +53,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-URL: https://statismike.github.io/shiny.reglog/
+URL: https://statismike.github.io/shiny.reglog/,
+    https://github.com/StatisMike/shiny.reglog
+BugReports: https://github.com/StatisMike/shiny.reglog/issues

--- a/R/mail_handlers.R
+++ b/R/mail_handlers.R
@@ -310,7 +310,7 @@ gmailr_custom_mail_handler <- function(self, private, message) {
   
   # and send it!
   message_to_send <- tryCatch({
-    gmailr::send_message(mail)
+    gmailr::gm_send_message(mail)
     
     RegLogConnectorMessage(
       message$type,


### PR DESCRIPTION
gmailr has been on a path to removing functions without the `gm_` prefix for several years now. They were all hard-deprecated in 2023 and I'm about to remove them entirely. This PR removes one last use of `send_message()` here. Looks like this was just an oversight, because this package does seem to already use `gm_` functions, in general.

https://tidyverse.org/blog/2023/06/gmailr-2-0-0/#progress-on-the-great-renaming

I also added the "usual" links to this GitHub repo to DESCRIPTION and it makes this repo much easier for people like me to find, if they need to make a pull request or open an issue.